### PR TITLE
Made the LikeButton render individually where as before it would re-r…

### DIFF
--- a/src/components/CardUtils/CardUtils.js
+++ b/src/components/CardUtils/CardUtils.js
@@ -1,29 +1,35 @@
-import React, { useState } from "react";
-import { NameButton, SoundEffectButton, FactButton } from "components";
+import React from "react";
+import {
+  NameButton,
+  SoundEffectButton,
+  FactButton,
+  LikeButton,
+} from "components";
 import {
   Utils,
   NameHolder,
   DestructButton,
   IconHolder,
-  IconHeartLiked,
-  IconHeartNotLiked,
 } from "./CardUtils.styles";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faShapes, faHeart } from "@fortawesome/free-solid-svg-icons";
+import { faShapes } from "@fortawesome/free-solid-svg-icons";
 
-export default function CardUtils({ name, nameSound, funFacts, getAudio, id, category, handleLike, xSectionCloser, isLiked, ...props }) {
-  const handleLikeHeart = (id, category, list) => {
-    handleLike(id, category, list);
-  };
-
+export default function CardUtils({
+  name,
+  nameSound,
+  funFacts,
+  getAudio,
+  id,
+  category,
+  handleLike,
+  xSectionCloser,
+  isLiked,
+  list,
+}) {
   return (
     <Utils>
       <NameHolder>
-      <NameButton
-        name={name.eng}
-        nameSound={nameSound}
-        category={category}
-      />
+        <NameButton name={name.eng} nameSound={nameSound} category={category} />
         <DestructButton onClick={() => xSectionCloser()}>
           <button>
             <FontAwesomeIcon icon={faShapes} />
@@ -31,25 +37,20 @@ export default function CardUtils({ name, nameSound, funFacts, getAudio, id, cat
         </DestructButton>
       </NameHolder>
       <IconHolder>
-        <SoundEffectButton
-          nameSound={nameSound}
-          category={category}
-        />
+        <SoundEffectButton nameSound={nameSound} category={category} />
         <FactButton
           name={name.eng}
           nameSound={nameSound}
           funFacts={funFacts}
           getAudio={getAudio}
         />
-        {isLiked ? ( // Simplify this button's functionality
-          <IconHeartLiked onClick={() => handleLikeHeart(id, category, props.list)}>
-            <FontAwesomeIcon icon={faHeart} />
-          </IconHeartLiked>
-        ) : (
-          <IconHeartNotLiked onClick={() => handleLikeHeart(id, category, props.list)}>
-            <FontAwesomeIcon icon={faHeart} />
-          </IconHeartNotLiked>
-        )}
+        <LikeButton
+          handleLike={handleLike}
+          isLiked={isLiked}
+          id={id}
+          category={category}
+          list={list}
+        />
       </IconHolder>
     </Utils>
   );

--- a/src/components/LikeButton/LikeButton.js
+++ b/src/components/LikeButton/LikeButton.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import {
+  IconDisabled,
+  IconHeartLiked,
+  IconHeartNotLiked,
+} from "./LikeButton.styles";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faHeart } from "@fortawesome/free-solid-svg-icons";
+
+export default function LikeButton({
+  handleLike,
+  isLiked,
+  id,
+  category,
+  ...props
+}) {
+  const playing = useSelector((state) => state.playing.value);
+  const handleLikeHeart = (id, category, list) => {
+    handleLike(id, category, list);
+  };
+
+  return playing ? (
+    isLiked ? (
+      <IconHeartLiked onClick={() => handleLikeHeart(id, category, props.list)}>
+        <FontAwesomeIcon icon={faHeart} />
+      </IconHeartLiked>
+    ) : (
+      <IconHeartNotLiked
+        onClick={() => handleLikeHeart(id, category, props.list)}
+      >
+        <FontAwesomeIcon icon={faHeart} />
+      </IconHeartNotLiked>
+    )
+  ) : (
+    <IconDisabled>
+      <FontAwesomeIcon icon={faHeart} />
+    </IconDisabled>
+  );
+}

--- a/src/components/LikeButton/LikeButton.styles.js
+++ b/src/components/LikeButton/LikeButton.styles.js
@@ -1,0 +1,25 @@
+import styled from "styled-components";
+
+export const IconHeartLiked = styled.div`
+  font-size: 27px;
+  cursor: pointer;
+  color: #ff6347;
+  &:hover {
+    color: #ff9380;
+  }
+`;
+
+export const IconHeartNotLiked = styled.div`
+  font-size: 27px;
+  cursor: pointer;
+  color: #2f4f4f;
+  &:hover {
+    color: #4d8080;
+  }
+`;
+
+export const IconDisabled = styled.div`
+  font-size: 27px;
+  cursor: not-allowed;
+  color: #8fbcbc;
+`;

--- a/src/components/LikeButton/index.js
+++ b/src/components/LikeButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './LikeButton.js'

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -13,3 +13,4 @@ export { default as SyllableTile } from "./SyllableTile";
 export { default as FactorUnitAnimations } from "./FactorUnitAnimations";
 export { default as Menu } from "./Menu";
 export { default as Header } from "./Header";
+export { default as LikeButton } from "./LikeButton";

--- a/src/pages/CardDetail/CardDetail.js
+++ b/src/pages/CardDetail/CardDetail.js
@@ -41,6 +41,8 @@ export default function CardDetail({
   };
 
   let item = list[list.findIndex(itemIndex)];
+
+  console.log(list.findIndex(itemIndex))
   
   const xSectionCloser = () => {
     const clicked = isDestructOpen;


### PR DESCRIPTION
…ender everything on the CardDetails page. There's this other bug where all of the CardUtils buttons are re-rendered when the LikeButton is clicked. For now, I have disabled the LikeButton so that the user can't click on it when a fact is playing. Once I place the zebrAPI object in the store, I'll change the LikeButton functionality so that it doesn't re-render all of the buttons.